### PR TITLE
feat: add cargo home

### DIFF
--- a/rust/1.84-25.04/rockcraft.yaml
+++ b/rust/1.84-25.04/rockcraft.yaml
@@ -32,8 +32,9 @@ platforms:
   amd64:
   arm64:
 
+# https://doc.rust-lang.org/cargo/reference/environment-variables.html
 environment:
-    # ...
+  CARGO_HOME: /cargo
 
 parts:
   rust:


### PR DESCRIPTION
add `CARGO_HOME` env variable which cargo uses for its files -- primarily the downloaded packages cache