### PR TITLE
feat: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the SDK [rock](https://documentation.ubuntu.com/server/explanation/virtualisation/about-rock-images/) definitions for the [rust](https://www.rust-lang.org/) programming language.
 
-This contains a minimal Rust 1.84 toolchain and Cargo build system which can be used to build a wide variety of Rust applications. It also includes a minimal GCC toolchain to custom build steps in Cargo builds.
+This contains a minimal Rust toolchain and Cargo build system which can be used to build a wide variety of Rust applications. It also includes a minimal GCC toolchain to custom build steps in Cargo builds.
 
 Any additional dependencies can be either mounted at runtime or installed
 with the apt installation included in this rock.
@@ -21,11 +21,11 @@ cd sudo-rs
 Now lets launch the rust container with the code directory mounted:
 
 ```bash
-$ docker run --name=my-rust-rock --rm -it -v ./:/work rust:1.84
-2025-10-06T09:12:26.508Z [pebble] {"type":"security","datetime":"2025-10-06T09:12:26Z","level":"WARN","event":"sys_startup:0","description":"Starting daemon","appid":"pebble"}
-2025-10-06T09:12:26.508Z [pebble] Started daemon.
-2025-10-06T09:12:26.509Z [pebble] POST /v1/services 81.875µs 400 (http+unix)
-2025-10-06T09:12:26.509Z [pebble] Cannot start default services: no default services
+$ docker run --name=my-rust-rock --rm -it -v ./:/work rust:1.75
+2025-12-17T16:33:37.340Z [pebble] {"type":"security","datetime":"2025-12-17T16:33:37Z","level":"WARN","event":"sys_startup:0","description":"Starting daemon","appid":"pebble"}
+2025-12-17T16:33:37.341Z [pebble] Started daemon.
+2025-12-17T16:33:37.341Z [pebble] POST /v1/services 78.436µs 400 (http+unix)
+2025-12-17T16:33:37.341Z [pebble] Cannot start default services: no default services
 ```
 
 The rock is running, but [`pebble`](https://github.com/canonical/pebble) - the container entrypoint does not have any entry point. This is fine! This is not a rock with a service. Its for building applications. Let's now log into the container and build the application. In a separate terminal run:
@@ -60,4 +60,5 @@ Voilà.
 
 ## Available versions
 
+* [Rust 1.75 (Ubuntu 24.04)](./rust/1.75-25.04/rockcraft.yaml)
 * [Rust 1.84 (Ubuntu 25.04)](./rust/1.84-25.04/rockcraft.yaml)


### PR DESCRIPTION
we have a new version of rust so 1) ive added it to available versions and 2) i've updated the readme to point at the LTS version (also since 25.04 is soon EOL).

i've checked that the example in the readme still works with rust 1.75 (sudo-rs has a minimal rust version 1.70)

- d0oes not conflict with https://github.com/canonical/rust-rock/pull/10